### PR TITLE
Exposing `WebSocketReadyState` enum to Objective-C

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -131,7 +131,7 @@ public enum WebSocketBinaryType : CustomStringConvertible {
 }
 
 /// The WebSocketReadyState enum is used by the readyState property to describe the status of the WebSocket connection.
-public enum WebSocketReadyState : Int, CustomStringConvertible {
+@objc public enum WebSocketReadyState : Int, CustomStringConvertible {
     /// The connection is not yet open.
     case Connecting = 0
     /// The connection is open and ready to communicate.

--- a/Test-ObjectiveC/Connection.m
+++ b/Test-ObjectiveC/Connection.m
@@ -28,12 +28,14 @@
     _webSocket = [[WebSocket alloc] init:@"ws://localhost:9000"];
     _webSocket.delegate = self;
     [_webSocket open];
+    NSAssert(_webSocket.readyState == WebSocketReadyStateConnecting, @"WebSocket is not connecting");
 }
 
 - (void)webSocketOpen {
     NSLog(@"Open");
     [_webSocket sendWithText:@"test"];
     [_webSocket sendWithData:[@"test" dataUsingEncoding:NSUTF8StringEncoding]];
+    NSAssert(_webSocket.readyState == WebSocketReadyStateOpen, @"WebSocket is not ready to communicate");
     [_webSocket close:0 reason:@""];
 }
 


### PR DESCRIPTION
A missing piece for Objective-C support 😁
