### PR TITLE
Bugfix: reusing websocket doesn't work

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -1669,7 +1669,7 @@ public class WebSocket: NSObject {
         opened = true
         ws = InnerWebSocket(request: request, subProtocols: subProtocols, stub: false)
         super.init()
-        ws.eclose = {
+        ws.eclose = { [unowned self] in
             self.opened = false
         }
     }
@@ -1678,7 +1678,7 @@ public class WebSocket: NSObject {
         opened = false
         ws = InnerWebSocket(request: NSURLRequest(), subProtocols: [], stub: true)
         super.init()
-        ws.eclose = {
+        ws.eclose = { [unowned self] in
             self.opened = false
         }
     }

--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -1666,21 +1666,17 @@ public class WebSocket: NSObject {
     }
     /// Create a WebSocket connection from an NSURLRequest; Also include a list of protocols.
     public init(request: NSURLRequest, subProtocols : [String] = []){
-        opened = true
-        ws = InnerWebSocket(request: request, subProtocols: subProtocols, stub: false)
+        let hasURL = request.URL != nil
+        opened = hasURL
+        ws = InnerWebSocket(request: request, subProtocols: subProtocols, stub: !hasURL)
         super.init()
         ws.eclose = { [unowned self] in
             self.opened = false
         }
     }
     /// Create a WebSocket object with a deferred connection; the connection is not opened until the .open() method is called.
-    public override init(){
-        opened = false
-        ws = InnerWebSocket(request: NSURLRequest(), subProtocols: [], stub: true)
-        super.init()
-        ws.eclose = { [unowned self] in
-            self.opened = false
-        }
+    public convenience override init(){
+        self.init(request: NSURLRequest(), subProtocols: [])
     }
     /// The URL as resolved by the constructor. This is always an absolute URL. Read only.
     public var url : String{ return ws.url }

--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -1668,6 +1668,10 @@ public class WebSocket: NSObject {
     public init(request: NSURLRequest, subProtocols : [String] = []){
         opened = true
         ws = InnerWebSocket(request: request, subProtocols: subProtocols, stub: false)
+        super.init()
+        ws.eclose = {
+            self.opened = false
+        }
     }
     /// Create a WebSocket object with a deferred connection; the connection is not opened until the .open() method is called.
     public override init(){


### PR DESCRIPTION
It appears that `opened` state isn't set to false when server hangs up and closes the websocket. So, if we try to reuse the websocket via the `open` method, the method simply returns (without reconnecting the websocket) because `opened` is `true`.

_Steps to reproduce the issue:_
- Instantiate and open websocket connection to the server

``` swift
let ws = WebSocket(request: request, subProtocols: ["protocol"])
```
- Have the server drop the connection
- Try to re-connect the websocket

``` swift
ws.open()
```

_Result:_ Websocket doesn't re-connect
