### PR TITLE
Sub-protocol now separate with a comma

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -994,7 +994,7 @@ private class InnerWebSocket: Hashable {
         }
         req.setValue(req.URL!.absoluteString, forHTTPHeaderField: "Origin")
         if subProtocols.count > 0 {
-            req.setValue(subProtocols.joinWithSeparator(";"), forHTTPHeaderField: "Sec-WebSocket-Protocol")
+            req.setValue(subProtocols.joinWithSeparator(","), forHTTPHeaderField: "Sec-WebSocket-Protocol")
         }
         if req.URL!.scheme != "wss" && req.URL!.scheme != "ws" {
             throw WebSocketError.InvalidAddress


### PR DESCRIPTION
According to [RFC 6455](https://tools.ietf.org/html/rfc6455) and [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), the list of sub-protocols given to the server must be separated by a comma, and not a semi-colon as is currently implemented.

This pull request changes the delimiter to a comma.
