### PR TITLE
added public initializer to WebSocketEvents

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -111,6 +111,8 @@ public struct WebSocketEvents {
     public var pong : (_ data : Any)->() = {(data) in}
     /// An event to be called when the WebSocket process has ended; this event is guarenteed to be called once and can be used as an alternative to the "close" or "error" events.
     public var end : (_ code : Int, _ reason : String, _ wasClean : Bool, _ error : Error?)->() = {(code, reason, wasClean, error) in}
+
+    public init() {}
 }
 
 /// The WebSocketBinaryType enum is used by the binaryType property and indicates the type of binary data being transmitted by the WebSocket connection.


### PR DESCRIPTION
I've created a protocol with the WebSocket methods I use, and define WebSocket to conform to it. This is so I can run unit tests without having to open an actual network connection. However, I cannot create a mock class since there is no way to initialize a WebSocketEvent. This request adds a public init method with no parameters.