### PR TITLE
Update podspec to 2.6.6

### DIFF
--- a/SwiftWebSocket.podspec
+++ b/SwiftWebSocket.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                   = "SwiftWebSocket"
-  s.version                = "2.6.5"
+  s.version                = "2.6.6"
   s.summary                = "A high performance WebSocket client library for Swift."
   s.homepage               = "https://github.com/tidwall/SwiftWebSocket"
   s.license                = { :type => "Attribution License", :file => "LICENSE" }


### PR DESCRIPTION
Create a new tag to include recent code changes.

This is necessary when using SwiftWebsocket as a dependency in your own podspec or your podspec needs to be updated with the --allow-warnings flag.