### PR TITLE
Update podspec to allow static library.

### DIFF
--- a/SwiftWebSocket.podspec
+++ b/SwiftWebSocket.podspec
@@ -13,4 +13,6 @@ Pod::Spec.new do |s|
   s.source_files           = "Source/*.swift"
   s.requires_arc           = true
   s.libraries              = 'z'
+  s.static_framework       = true
+  s.swift_version          = '4.0'
 end


### PR DESCRIPTION
Version [1.4.0 of Cocoapods](http://blog.cocoapods.org/CocoaPods-1.4.0/) allows a pod to be used as a static library, even in a Swift app. It requires the library's podspec to contain `s.static_framework = true`.

This little change works in my project.

I believe this will help apps launch faster. Here's a blog post that explains why too many dynamic frameworks slows down launch: https://blog.automatic.com/how-we-cut-our-ios-apps-launch-time-in-half-with-this-one-cool-trick-7aca2011e2ea