### PR TITLE
Handle close code if it was not handled before closing

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -765,6 +765,7 @@ private class InnerWebSocket: Hashable {
                 privateReadyState = .closed
                 if rd != nil {
                     closeConn()
+                    handleCloseCodeFromFirstCloseFrameIfNeeded()
                     fire {
                         self.eclose()
                         self.event.close(Int(self.closeCode), self.closeReason, self.closeFinal)
@@ -901,6 +902,19 @@ private class InnerWebSocket: Hashable {
             }
         }
     }
+    
+    func handleCloseCodeFromFirstCloseFrameIfNeeded() {
+        guard closeCode == 0 else { return }
+        
+        for frame in frames {
+            if frame.code == .close {
+                closeCode = frame.statusCode
+                closeReason = frame.utf8.text
+                return
+            }
+        }
+    }
+    
     @inline(__always) func fire(_ block: ()->()){
         if let queue = eventQueue {
             queue.sync {


### PR DESCRIPTION
WebSocket not handle close code when connection was closed by server.
I handle code on closing.