### PR TITLE
Add `required` to designated initializers

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -1668,7 +1668,7 @@ open class WebSocket: NSObject {
         self.init(request: URLRequest(url: URL(string: url)!), subProtocols: [subProtocol])
     }
     /// Create a WebSocket connection from an NSURLRequest; Also include a list of protocols.
-    public init(request: URLRequest, subProtocols : [String] = []){
+    public required init(request: URLRequest, subProtocols : [String] = []){
         let hasURL = request.url != nil
         opened = hasURL
         ws = InnerWebSocket(request: request, subProtocols: subProtocols, stub: !hasURL)
@@ -1683,7 +1683,7 @@ open class WebSocket: NSObject {
         }
     }
     /// Create a WebSocket object with a deferred connection; the connection is not opened until the .open() method is called.
-    public convenience override init(){
+    public required convenience override init(){
         var request = URLRequest(url: URL(string: "http://apple.com")!)
         request.url = nil
         self.init(request: request, subProtocols: [])

--- a/SwiftWebSocket.podspec
+++ b/SwiftWebSocket.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name                   = "SwiftWebSocket"
-  s.version                = "2.7.0"
+  s.version                = "2.7.1"
   s.summary                = "A high performance WebSocket client library for Swift."
   s.homepage               = "https://github.com/tidwall/SwiftWebSocket"
   s.license                = { :type => "Attribution License", :file => "LICENSE" }
-  s.source                 = { :git => "https://github.com/tidwall/SwiftWebSocket.git", :tag => "v2.7.0" }
+  s.source                 = { :git => "https://github.com/tidwall/SwiftWebSocket.git", :tag => "v2.7.1" }
   s.authors                = { 'Josh Baker' => 'joshbaker77@gmail.com' }
   s.social_media_url       = "https://twitter.com/tidwall"
   s.ios.deployment_target  = "8.0"


### PR DESCRIPTION
This fix is for swift 4.

Add the keyword required to designated initializers for protocol extension.

I found that @danthorpe forked this repo to add protocols to the class WebSocket, and the protocol could be extracted out of this repo.

https://github.com/danthorpe/SwiftWebSocket/blob/SWS-9_websockettype_protocol/Source/WebSocket.swift#L1677

To make a generic type instantiatable, we need to make the designated initializers marked with the keyword required.