### PR TITLE
fix circular reference when using WebSocketDelegate

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -536,7 +536,7 @@ private class InnerWebSocket: Hashable {
     var _allowSelfSignedSSL = false
     var _services = WebSocketService.None
     var _event = WebSocketEvents()
-    var _eventDelegate: WebSocketDelegate?
+    weak var _eventDelegate: WebSocketDelegate?
     var _binaryType = WebSocketBinaryType.uInt8Array
     var _readyState = WebSocketReadyState.connecting
     var _networkTimeout = TimeInterval(-1)


### PR DESCRIPTION
Changed the WebSocketDelegate var in InnerWebSocket to a `weak` reference