### PR TITLE
Swift 5 deprecated PackageDescription API v3.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,21 @@
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
-    name: "SwiftWebSocket"
+    name: "SwiftWebSocket",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "SwiftWebSocket",
+            targets: ["SwiftWebSocket"]),
+    ],
+    targets: [
+        .target(
+            name: "SwiftWebSocket",
+            path: "Source"),
+        .testTarget(
+            name: "Test",
+            dependencies: ["SwiftWebSocket"],
+            path: "Test"),
+    ]
 )


### PR DESCRIPTION
Swift 5 deprecated PackageDescription API v3 finally.
So you need to describe Package.swift in v4 manner.