### PR TITLE
Update SPM package description & SemVer tag for version 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,12 @@
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
-    name: "SwiftWebSocket"
+    name: "SwiftWebSocket",
+		products: [
+			.library(name: "SwiftWebSocket", targets: ["SwiftWebSocket"])
+		],
+		targets: [
+			.target(name: "SwiftWebSocket", path: "Source")
+		]
 )


### PR DESCRIPTION
Xcode 11 now supports Swift Package Manager, but so far it is not possible to add SwiftWebSocket to project via Xcode 11 SPM without proper repository version tag that follows Semantic Versioning (should be "2.8.0" without "v", but latest tag is "v2.8.0"). Pull request updates SPM package description for SwiftWebSocket.