### PR TITLE
- add SWS prefix to WebSocket class name

### DIFF
--- a/Source/SWSWebSocket.swift
+++ b/Source/SWSWebSocket.swift
@@ -1651,14 +1651,14 @@ private let manager = Manager()
 
 /// WebSocket objects are bidirectional network streams that communicate over HTTP. RFC 6455.
 @objcMembers
-open class WebSocket: NSObject {
+open class SWSWebSocket: NSObject {
     fileprivate var ws: InnerWebSocket
     fileprivate var id = manager.nextId()
     fileprivate var opened: Bool
 
     open override var hash: Int { return id }
     open override func isEqual(_ other: Any?) -> Bool {
-        guard let other = other as? WebSocket else { return false }
+        guard let other = other as? SWSWebSocket else { return false }
         return self.id == other.id
     }
     
@@ -1811,11 +1811,11 @@ open class WebSocket: NSObject {
     }
 }
 
-public func ==(lhs: WebSocket, rhs: WebSocket) -> Bool {
+public func ==(lhs: SWSWebSocket, rhs: SWSWebSocket) -> Bool {
     return lhs.id == rhs.id
 }
 
-extension WebSocket {
+extension SWSWebSocket {
     /// The events of the WebSocket using a delegate.
     @objc
     public var delegate : WebSocketDelegate? {

--- a/SwiftWebSocket.xcodeproj/project.pbxproj
+++ b/SwiftWebSocket.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		031967101B4D96C40033860E /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03285D2A1B4A9F1A0078A1AA /* WebSocket.swift */; };
-		03285D2B1B4A9F1A0078A1AA /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03285D2A1B4A9F1A0078A1AA /* WebSocket.swift */; };
+		031967101B4D96C40033860E /* SWSWebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03285D2A1B4A9F1A0078A1AA /* SWSWebSocket.swift */; };
+		03285D2B1B4A9F1A0078A1AA /* SWSWebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03285D2A1B4A9F1A0078A1AA /* SWSWebSocket.swift */; };
 		03957A461C5A734C005CC1DB /* SwiftWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = D71948F11B35E5670015C529 /* SwiftWebSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		03957A471C5A7392005CC1DB /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03285D2A1B4A9F1A0078A1AA /* WebSocket.swift */; };
+		03957A471C5A7392005CC1DB /* SWSWebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03285D2A1B4A9F1A0078A1AA /* SWSWebSocket.swift */; };
 		03957A4C1C5A7532005CC1DB /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 03957A4B1C5A7532005CC1DB /* libz.dylib */; };
 		03D1E7221B208A5C00AC49AC /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 03D1E7211B208A5C00AC49AC /* libz.dylib */; };
 		03D70CD11BDAC5EC00D245C3 /* SwiftWebSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D71949011B35E6130015C529 /* SwiftWebSocket.framework */; };
@@ -51,7 +51,7 @@
 
 /* Begin PBXFileReference section */
 		0319670F1B4D96B80033860E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		03285D2A1B4A9F1A0078A1AA /* WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
+		03285D2A1B4A9F1A0078A1AA /* SWSWebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SWSWebSocket.swift; sourceTree = "<group>"; };
 		03957A3C1C5A71DB005CC1DB /* SwiftWebSocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftWebSocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		03957A481C5A74D9005CC1DB /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		03957A4B1C5A7532005CC1DB /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/lib/libz.dylib; sourceTree = DEVELOPER_DIR; };
@@ -164,7 +164,7 @@
 				03957A481C5A74D9005CC1DB /* Info-tvOS.plist */,
 				0319670F1B4D96B80033860E /* Info.plist */,
 				D71948F11B35E5670015C529 /* SwiftWebSocket.h */,
-				03285D2A1B4A9F1A0078A1AA /* WebSocket.swift */,
+				03285D2A1B4A9F1A0078A1AA /* SWSWebSocket.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -423,7 +423,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				03957A471C5A7392005CC1DB /* WebSocket.swift in Sources */,
+				03957A471C5A7392005CC1DB /* SWSWebSocket.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -431,7 +431,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				03285D2B1B4A9F1A0078A1AA /* WebSocket.swift in Sources */,
+				03285D2B1B4A9F1A0078A1AA /* SWSWebSocket.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -455,7 +455,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				031967101B4D96C40033860E /* WebSocket.swift in Sources */,
+				031967101B4D96C40033860E /* SWSWebSocket.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Test-ObjectiveC/Connection.m
+++ b/Test-ObjectiveC/Connection.m
@@ -14,7 +14,7 @@
 @end
 
 @implementation Connection {
-    WebSocket *_webSocket;
+    SWSWebSocket *_webSocket;
 }
 
 - (instancetype)init {
@@ -25,7 +25,7 @@
 }
 
 - (void)open {
-    _webSocket = [[WebSocket alloc] init:@"ws://localhost:9000"];
+    _webSocket = [[SWSWebSocket alloc] init:@"ws://localhost:9000"];
     _webSocket.delegate = self;
     [_webSocket open];
     NSAssert(_webSocket.readyState == WebSocketReadyStateConnecting, @"WebSocket is not connecting");


### PR DESCRIPTION
Missing prefix leads to conflicts with other 3rd party libs written in Objective C due to missing namespacing in Objective C